### PR TITLE
Fix python_version format

### DIFF
--- a/maxmind.json
+++ b/maxmind.json
@@ -21,10 +21,7 @@
     "latest_tested_versions": [
         "GeoLite2-City MMDB Updated 2024-03-11"
     ],
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "configuration": {
         "ip_address": {
             "data_type": "string",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)